### PR TITLE
fix: restore ICANN resolution in hnsd and persist chain state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,14 @@ RUN apk add --no-cache \
 # External dependencies are provisioned before the application source is copied
 # so that changes to the source do not invalidate these expensive layers.
 
-# Build hnsd (pinned for reproducibility).
-ARG HNSD_VERSION=v2.0.0
-RUN git clone --branch="${HNSD_VERSION}" --depth=1 https://github.com/handshake-org/hnsd.git && \
+# Build hnsd from a pinned commit. The v2.0.0 tag (2023) ships a stale ICANN
+# root-zone snapshot (src/tld.h) whose DS records predate the .com/.net DNSSEC
+# algorithm rollover, so DNSSEC validation fails (SERVFAIL) for those TLDs.
+# The fix is only on master; no release tag contains it.
+ARG HNSD_COMMIT=3c2cd7a2b744558ac159efced3898e7d5adbb4a6
+RUN git init --quiet ./hnsd && \
+    git -C ./hnsd fetch --depth=1 https://github.com/handshake-org/hnsd.git "${HNSD_COMMIT}" && \
+    git -C ./hnsd checkout --quiet FETCH_HEAD && \
     cd ./hnsd && \
     ./autogen.sh && \
     ./configure && \

--- a/hnsd/hnsd.go
+++ b/hnsd/hnsd.go
@@ -24,24 +24,32 @@ type Daemon struct {
 	rsHost      string // rsHost is the recursive resolver bind address (host:port).
 	poolSize    uint   // poolSize is the number of Handshake DNS peers.
 	maxRestarts int    // maxRestarts bounds restarts (0 disables, -1 unlimited).
+	prefixDir   string // prefixDir is the directory where hnsd persists chain state.
 }
 
 // New creates a new hnsd Daemon bound to the given recursive resolver host.
-func New(name, rsHost string, poolSize uint, maxRestarts int) *Daemon {
+func New(name, rsHost string, poolSize uint, maxRestarts int, prefixDir string) *Daemon {
 	return &Daemon{
 		Manager:     process.NewManager(name),
 		execFile:    "hnsd",
 		rsHost:      rsHost,
 		poolSize:    poolSize,
 		maxRestarts: maxRestarts,
+		prefixDir:   prefixDir,
 	}
 }
 
-// Setup verifies the hnsd binary is available before the Daemon is started.
+// Setup verifies the hnsd binary is available and creates the prefix directory
+// before the Daemon is started. hnsd refuses to start if the prefix directory
+// does not exist.
 func (d *Daemon) Setup(ctx context.Context) error {
 	return d.Manager.Setup(ctx, func() error { //nolint:wrapcheck
 		if _, err := exec.LookPath(d.execFile); err != nil {
 			return fmt.Errorf("looking up %q binary: %w", d.execFile, err)
+		}
+
+		if err := os.MkdirAll(d.prefixDir, 0o700); err != nil {
+			return fmt.Errorf("creating prefix directory %q: %w", d.prefixDir, err)
 		}
 
 		return nil
@@ -113,12 +121,17 @@ func (d *Daemon) shouldRestart(restarts int) bool {
 
 // command builds the hnsd process bound to the configured resolver host.
 // Only --rs-host is pinned; the authoritative root nameserver keeps its loopback default.
+// --checkpoint starts the initial sync from the hard-coded checkpoint instead of
+// genesis, and --prefix persists chain state across restarts so subsequent syncs
+// resume from the stored tip.
 func (d *Daemon) command(ctx context.Context) *exec.Cmd {
 	cmd := exec.CommandContext(
 		ctx,
 		d.execFile,
 		"--rs-host", d.rsHost,
 		"--pool-size", strconv.FormatUint(uint64(d.poolSize), 10),
+		"--checkpoint",
+		"--prefix", d.prefixDir,
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/hnsd/hnsd_test.go
+++ b/hnsd/hnsd_test.go
@@ -1,0 +1,73 @@
+package hnsd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestSetupCreatesPrefixDir(t *testing.T) {
+	// A nested, not-yet-existing path; hnsd itself refuses to start when the
+	// prefix directory is missing, so Setup must create it.
+	prefixDir := filepath.Join(t.TempDir(), "home", "hnsd")
+
+	d := New("hnsd", "10.8.0.1:53", 8, 5, prefixDir)
+	d.execFile = "sh" // stand-in binary so LookPath succeeds without hnsd installed
+
+	if err := d.Setup(context.Background()); err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+
+	info, err := os.Stat(prefixDir)
+	if err != nil {
+		t.Fatalf("prefix directory not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("prefix path %q is not a directory", prefixDir)
+	}
+}
+
+func TestCommandArgs(t *testing.T) {
+	d := New("hnsd", "10.8.0.1:53", 8, 5, "/data/.dvpnx/hnsd")
+
+	cmd := d.command(context.Background())
+
+	want := []string{
+		"hnsd",
+		"--rs-host", "10.8.0.1:53",
+		"--pool-size", "8",
+		"--checkpoint",
+		"--prefix", "/data/.dvpnx/hnsd",
+	}
+	if !slices.Equal(cmd.Args, want) {
+		t.Fatalf("command args = %v, want %v", cmd.Args, want)
+	}
+}
+
+func TestShouldRestart(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxRestarts int
+		restarts    int
+		want        bool
+	}{
+		{"disabled", 0, 0, false},
+		{"unlimited", -1, 1 << 20, true},
+		{"below limit", 5, 4, true},
+		{"at limit", 5, 5, false},
+		{"above limit", 5, 6, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := New("hnsd", "10.8.0.1:53", 8, tt.maxRestarts, t.TempDir())
+
+			if got := d.shouldRestart(tt.restarts); got != tt.want {
+				t.Fatalf("shouldRestart(%d) with maxRestarts=%d = %v, want %v",
+					tt.restarts, tt.maxRestarts, got, tt.want)
+			}
+		})
+	}
+}

--- a/node/setup.go
+++ b/node/setup.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"path/filepath"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -118,14 +119,16 @@ func (n *Node) SetupHandshakeDNS(ctx context.Context, cfg *config.Config) error 
 	}
 
 	rsHost := net.JoinHostPort(gateway, "53")
+	prefixDir := filepath.Join(n.Context().HomeDir(), "hnsd")
 
 	log.Info("Initializing Handshake DNS",
 		"rs_host", rsHost,
 		"pool_size", cfg.HandshakeDNS.GetPeers(),
 		"max_restarts", cfg.HandshakeDNS.GetMaxRestarts(),
+		"prefix_dir", prefixDir,
 	)
 
-	d := hnsd.New("hnsd", rsHost, cfg.HandshakeDNS.GetPeers(), cfg.HandshakeDNS.GetMaxRestarts())
+	d := hnsd.New("hnsd", rsHost, cfg.HandshakeDNS.GetPeers(), cfg.HandshakeDNS.GetMaxRestarts(), prefixDir)
 	if err := d.Setup(ctx); err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -49,7 +49,7 @@ function cmd_init {
       --interactive \
       --rm \
       --tty \
-      --volume "${NODE_DIR}:/root/.sentinelnode" \
+      --volume "${NODE_DIR}:/root/.sentinel-dvpnx" \
       "${NODE_IMAGE}" process "${@}"
   }
 
@@ -387,7 +387,7 @@ function cmd_start {
       --name="${CONTAINER_NAME}" \
       --rm="${rm}" \
       --tty \
-      --volume "${NODE_DIR}:/root/.sentinelnode" \
+      --volume "${NODE_DIR}:/root/.sentinel-dvpnx" \
       --publish "${node_api_port}:${node_api_port}/tcp" \
       --publish "${vmess_port}:${vmess_port}/tcp" \
       "${NODE_IMAGE}" process start
@@ -401,7 +401,7 @@ function cmd_start {
       --rm="${rm}" \
       --tty \
       --volume /lib/modules:/lib/modules \
-      --volume "${NODE_DIR}:/root/.sentinelnode" \
+      --volume "${NODE_DIR}:/root/.sentinel-dvpnx" \
       --cap-drop ALL \
       --cap-add NET_ADMIN \
       --cap-add NET_BIND_SERVICE \


### PR DESCRIPTION
## Problem

Handshake DNS on dvpnx nodes stopped resolving regular (ICANN) domains — every name under `.com`, `.net`, and other rolled TLDs returns SERVFAIL, which in practice makes the resolver unusable for clients.

**Root cause:** commit 049e282 pinned the hnsd build to the `v2.0.0` tag (January 2023). hnsd does not recurse to the real ICANN root — it serves TLD delegations from a baked-in root-zone snapshot (`src/tld.h`), validated by its embedded Unbound through hnsd's synthetic trust anchor. That snapshot went stale: Verisign rolled `.com`/`.net` DNSSEC from algorithm 8 (DS key tag 30909) to algorithm 13 (DS key tag 19718) in 2023, so the DS records hnsd v2.0.0 hands out no longer match the real zones' keys and validation fails closed.

Upstream fixed the snapshot on master (handshake-org/hnsd@8dccc02, "fix: Update tld.h file to fix issues with resolving ICANN domains") but has not tagged a release since v2.0.0, so pinning by tag cannot pick up the fix.

## Changes

- **Dockerfile:** build hnsd from pinned commit `3c2cd7a2b744558ac159efced3898e7d5adbb4a6` (current master head, contains the tld.h fix) using a shallow fetch of the pinned commit.
- **hnsd wrapper:** pass `--checkpoint` and `--prefix <home>/hnsd` to hnsd. Without `--checkpoint`, hnsd syncs headers from genesis on every start (the baked checkpoint is opt-in); without `--prefix`, no chain state survives a restart. hnsd requires the prefix directory to exist, so `Setup` now creates it.
- **scripts/runner.sh:** mount the node directory at `/root/.sentinel-dvpnx` (the CLI's actual default home) instead of `/root/.sentinelnode`, so hnsd chain state — and everything else under the home — actually lands on the mounted volume.
- **Tests:** add unit tests for hnsd command construction, restart-budget logic, and prefix-directory creation in `Setup`.

## Notes for reviewers

- `tld.h` is a static snapshot of a living zone and will rot again on future TLD key rollovers. Rebuilding the image whenever upstream refreshes the snapshot, plus monitoring signed ICANN resolution (`dig example.com +dnssec` expecting NOERROR/AD) through node resolvers, is recommended.
- The `--prefix` directory lives under the node home dir so it persists across container replacement when the home is mounted.

## Verification

- `go build ./...`, `go test ./hnsd/`, `go vet ./...` all pass; the Docker image builds, including the pinned hnsd commit (reports 2.99.0).
- DS record change confirmed by decoding the `.com` entry of `tld.h` in v2.0.0 (key tag 30909, alg 8) vs. the pinned commit (key tag 19718, alg 13), matching the documented Verisign rollover.
- Live run: hnsd started from the baked checkpoint (height 136,000), synced to the current tip, connected to peers, and retrieved the Handshake proof for `com`. The final validated end-to-end query could not be exercised in the test environment (outbound UDP/53 blocked), so it still needs confirmation on a real node.

## Manual verification after deployment

Run a node with `handshake-dns.enable = true`, wait for header sync, then from a connected client:

```
dig @<gateway> example.com. A +dnssec   # expect NOERROR with the ad flag (SERVFAILs on the old image)
dig @<gateway> <handshake-name>. A      # a Handshake-native name should still resolve
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Handshake DNS state is now persisted, allowing synchronization to resume without restarting from genesis.
  * Node setup now configures and reports the persistent data directory.

* **Bug Fixes**
  * Updated container data mounts to use the current node directory path.

* **Tests**
  * Added coverage for persistent directory creation, command options, and restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->